### PR TITLE
Modify BUG

### DIFF
--- a/Samples/DecodeVideo/main.cpp
+++ b/Samples/DecodeVideo/main.cpp
@@ -79,7 +79,7 @@ HIAI_StatusT HIAI_InitAndStartGraph(const std::vector<uint32_t>& graphs2run)
         return HIAI_ERROR;
     }
     // Step1: Global System Initialization before using HIAI Engine
-    HIAI_StatusT status = HIAI_Init(1);
+    HIAI_StatusT status = HIAI_Init(0);
     hiai::GraphConfigList glist;
     hiai::Graph::ParseConfigFile(GRAPH_FILENAME, glist);
     // append graphs

--- a/Samples/InferOfflineVideo/README.md
+++ b/Samples/InferOfflineVideo/README.md
@@ -106,6 +106,7 @@ label file path config
 ## Execution
 
 ```bash
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:<Ffmpeg Path>/lib
 cd out
 ./main
 ```

--- a/Samples/InferOfflineVideo/README.zh.md
+++ b/Samples/InferOfflineVideo/README.zh.md
@@ -107,6 +107,7 @@ export FFMPEG_PATH=/path/to/ffmpeg
 ## 运行
 
 ```bash
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:<Ffmpeg Path>/lib
 cd out
 ./main 
 ```


### PR DESCRIPTION
1、DecodeVideo 默认初始化，芯片1，但Atlas 500仅有一片芯片；
2、InferOfflineVideo 正常运行时，需要将ffmpeg的动态链接库添加到系统可检索路径